### PR TITLE
fix: change attributes only for script tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,18 +56,14 @@ class ModernBuildPlugin {
 
     const currentAssets =
       plugin.options.inject === "head" ? headTags : bodyTags;
+    const scripts = currentAssets.filter((a) => a.tagName === "script" && a.attributes);
+
+    this.setAttributesToScripts(scripts);
 
     if (assetsManager.hasAssets()) {
-      this.setAttributesToScripts(currentAssets);
       this.injectAssets(assetsManager.get(), currentAssets);
-
       assetsManager.remove();
     } else {
-      const scripts = currentAssets.filter(
-        (a) => a.tagName === "script" && a.attributes
-      );
-      this.setAttributesToScripts(scripts);
-
       assetsManager.set(scripts);
     }
 


### PR DESCRIPTION
Hello,

Great plugin, was actually looking for something like this and stumbled across your solution. There's an issue that hopefully this PR fixes.

When updating the attributes for the scripts, other assets are also modified. It seems <link/> tags are "broken" if you try and load them using type="module".